### PR TITLE
Add .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+	"proseWrap": "preserve",
+	"singleQuote": true,
+	"trailingComma": "es5",
+	"useTabs": true
+}


### PR DESCRIPTION
Prettier isn't installed in the repo by default, but having this file in the repo activates your editor's formatting plugins.